### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -10,6 +10,8 @@ jobs:
   test-build:
     name: Test build
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/sebdanielsson/nitmod/security/code-scanning/1](https://github.com/sebdanielsson/nitmod/security/code-scanning/1)

The best way to fix this problem is to add a `permissions` block explicitly defining the required permissions for the `test-build` job. Since this workflow does not seem to require write permissions, setting `contents: read` at the job level is sufficient. This ensures that the `GITHUB_TOKEN` has minimal access, reducing the risk of misuse.

The change will be made by adding a `permissions` block under the `test-build` job definition, specifying `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
